### PR TITLE
Change GeoIP db location to /var/lib

### DIFF
--- a/logstash/logstash.yaml
+++ b/logstash/logstash.yaml
@@ -59,12 +59,12 @@ spec:
       - name: templates
         mountPath: "/usr/share/logstash/templates"
       - name: geoip-data
-        mountPath: "/usr/share/GeoIP"
+        mountPath: "/var/lib/GeoIP"
 
     secretMounts:
       - name: geoip-secret
         secretName: geoip-secret
-        path: "/usr/share/GeoIP/config"
+        path: "/var/lib/GeoIP/config"
 
     extraPorts:
       - name: firewall
@@ -77,7 +77,7 @@ spec:
     lifecycle:
       postStart:
         exec:
-          command: ["/bin/sh", "-c", "rm /usr/share/logstash/pipeline/logstash.conf; curl -L 'https://github.com/maxmind/geoipupdate/releases/download/v4.3.0/geoipupdate_4.3.0_linux_amd64.tar.gz' | tar xz; chmod +x geoipupdate_4.3.0_linux_amd64/geoipupdate; ./geoipupdate_4.3.0_linux_amd64/geoipupdate -d /usr/share/GeoIP -f /usr/share/GeoIP/config/GeoIP.conf"]
+          command: ["/bin/sh", "-c", "rm /usr/share/logstash/pipeline/logstash.conf; curl -L 'https://github.com/maxmind/geoipupdate/releases/download/v4.3.0/geoipupdate_4.3.0_linux_amd64.tar.gz' | tar xz; chmod +x geoipupdate_4.3.0_linux_amd64/geoipupdate; ./geoipupdate_4.3.0_linux_amd64/geoipupdate -d /var/lib/GeoIP -f /var/lib/GeoIP/config/GeoIP.conf"]
   valuesFrom:
     - kind: ConfigMap
       name: logstash-01-inputs

--- a/logstash/pipelines/30-geoip.yaml
+++ b/logstash/pipelines/30-geoip.yaml
@@ -22,12 +22,12 @@ data:
               if "IP_Private_Source" not in [tags] {
                 geoip {
                   source => "[source][ip]"
-                  database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+                  database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
                   target => "[source][geo]"
                 }
                 geoip {
                   default_database_type => 'ASN'
-                  database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+                  database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
                   #cache_size => 5000
                   source => "[source][ip]"
                   target => "[source][as]"
@@ -51,12 +51,12 @@ data:
               if "IP_Private_Destination" not in [tags] {
                 geoip {
                   source => "[destination][ip]"
-                  database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+                  database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
                   target => "[destination][geo]"
                 }
                 geoip {
                   default_database_type => 'ASN'
-                  database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+                  database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
                   #cache_size => 5000
                   source => "[destination][ip]"
                   target => "[destination][as]"
@@ -83,12 +83,12 @@ data:
               if "IP_Private_HAProxy" not in [tags] {
                 geoip {
                   source => "[haproxy][client][ip]"
-                  database => "/usr/share/GeoIP/GeoLite2-City.mmdb"
+                  database => "/var/lib/GeoIP/GeoLite2-City.mmdb"
                   target => "[source][geo]"
                 }
                 geoip {
                   default_database_type => 'ASN'
-                  database => "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
+                  database => "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
                   #cache_size => 5000
                   source => "[haproxy][client][ip]"
                   target => "[source][as]"


### PR DESCRIPTION
/var/lib : Variable state information
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html
/usr/share : Architecture-independent data
https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html

/var/lib/GeoIP seems to be a location more fitting for the geoip db files